### PR TITLE
Add `Rank`, `Suit`, and `Hand` structs

### DIFF
--- a/src/card.rs
+++ b/src/card.rs
@@ -1,106 +1,158 @@
-use array_init;
 use rand::Rng;
 use std::fmt;
 
-#[derive(PartialEq, PartialOrd)]
+//////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(PartialEq, Eq, PartialOrd, Debug, Copy, Clone)]
+pub struct Suit {
+    pub id: usize,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Debug, Copy, Clone)]
+pub struct Rank {
+    pub id: usize,
+}
+
+#[derive(PartialEq, Eq, PartialOrd, Debug, Copy, Clone)]
 pub struct Card {
-    pub id: i32,
+    pub id: usize,
+}
+
+pub struct Hand<const N: usize> {
+    pub cards: [Card; N],
+}
+
+//////////////////////////////////////////////////////////////////////////////////////
+impl Suit {
+    pub const NUM_SUITS: usize = 4;
+}
+
+/// One of:  {♥, ♣, ♦, ♠, ?}
+impl fmt::Display for Suit {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self.id {
+                0 => String::from("♣"),
+                1 => String::from("♦"),
+                2 => String::from("♥"),
+                3 => String::from("♠"),
+                _ => String::from("?"),
+            }
+        )
+    }
+}
+
+impl Rank {
+    #[allow(dead_code)]
+    pub const NUM_RANKS: usize = 13;
+}
+
+/// One of:  {A, 2, 3, ... 8, 9, T, J, Q, K}
+impl fmt::Display for Rank {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let one_based_index = self.id + 1;
+
+        write!(
+            f,
+            "{}",
+            match one_based_index {
+                1 => String::from("A"),
+                10 => String::from("T"),
+                11 => String::from("J"),
+                12 => String::from("Q"),
+                13 => String::from("K"),
+                _ => one_based_index.to_string(),
+            }
+        )
+    }
 }
 
 impl Card {
+    pub const NUM_CARDS: usize = Suit::NUM_SUITS * Rank::NUM_RANKS;
+
+    #[allow(dead_code)]
+    pub fn new(rank: &Rank, suit: &Suit) -> Card {
+        Card {
+            id: rank.id * Suit::NUM_SUITS + suit.id,
+        }
+    }
+
     /// Returns the suit (club, spade, heart, diamond) of this [`Card`],
     /// where the suit is represented as an integer.
-    pub fn suit(&self) -> i32 {
-        self.id % 4
+    pub fn suit(&self) -> Suit {
+        Suit {
+            id: (self.id % Suit::NUM_SUITS),
+        }
     }
 
     /// Returns the "index" (ace, two, three, ... jack, queen, king) of the [`Card`].
-    pub fn index(&self) -> i32 {
-        self.id / 4
+    pub fn rank(&self) -> Rank {
+        Rank {
+            id: (self.id / Suit::NUM_SUITS),
+        }
     }
 
     pub fn draw_random_card<R: Rng>(rng: &mut R) -> Card {
         Card {
-            id: rng.gen_range(0..51),
+            id: rng.gen_range(0..Card::NUM_CARDS),
         }
     }
+}
 
+/// Examples:  K♥ A♣ Q♥ 3♦ 7 8♠ 2♥
+impl fmt::Display for Card {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.rank(), self.suit())
+    }
+}
+
+impl<const N: usize> Hand<N> {
     /// Check for duplicates in the array, starting with `start_index`.
     /// Return the index of the first duplicate found.
     /// The `start_index` parameter allows the search to resume after replacing
     /// a duplicate entry.
-    fn check_for_duplicates<const N: usize>(
-        start_index: usize,
-        cards: &[Card; N],
-    ) -> Option<usize> {
+    fn check_for_duplicates(&self, start_index: usize) -> Option<usize> {
         for i in start_index..N {
             for j in 0..i {
-                if cards[i] == cards[j] {
+                if self.cards[i] == self.cards[j] {
                     return Some(i);
                 }
             }
         }
-        return None;
+        None
     }
 
-    /// Returns an array of N cards that are sampled from the deck without replacement
-    /// Note: this algorithm is efficient for small N, but is very slow as N approaches
-    /// 51. For values larger than 51 it will block forever. For now, this is private
-    /// to the module so that it can only be called when N << 52.
-    fn draw_without_replacement<const N: usize, R: Rng>(rng: &mut R) -> [Card; N] {
+    /// Returns an array of N cards that are sampled from the deck without
+    /// replacement Note: this algorithm is efficient for small N, but is very
+    /// slow as N approaches Card::NUM_CARDS. For values larger than
+    /// (Card::NUM_CARDS-1) it will block forever. For now, this is private to
+    /// the module so that it can only be called when N << Card::NUM_CARDS.
+    pub fn draw<R: Rng>(rng: &mut R) -> Hand<N> {
         // Draw N cards with replacement
-        let mut hand: [Card; N] = array_init::array_init(|_| Card::draw_random_card(rng));
+        let mut hand = Hand {
+            cards: array_init::array_init(|_| Card::draw_random_card(rng)),
+        };
         // Replace any duplicates.
-        let mut start_index = 1;
-        while let Some(i) = Card::check_for_duplicates(start_index, &hand) {
-            hand[i] = Card::draw_random_card(rng);
+        let mut start_index: usize = 1;
+        while let Some(i) = hand.check_for_duplicates(start_index) {
+            hand.cards[i] = Card::draw_random_card(rng);
             start_index = i;
         }
         hand
     }
-
-    pub fn draw_five_cards<R: Rng>(rng: &mut R) -> [Card; 5] {
-        Card::draw_without_replacement::<5, R>(rng)
-    }
-
-    pub fn draw_seven_cards<R: Rng>(rng: &mut R) -> [Card; 7] {
-        Card::draw_without_replacement::<7, R>(rng)
-    }
-
-    pub fn suit_to_string(&self) -> String {
-        match self.suit() {
-            0 => String::from("♣"),
-            1 => String::from("♦"),
-            2 => String::from("♥"),
-            3 => String::from("♠"),
-            _ => String::from("?"),
-        }
-    }
-
-    pub fn index_to_string(&self) -> String {
-        let one_based_index = self.index() + 1;
-        match one_based_index {
-            1 => String::from("A"),
-            11 => String::from("J"),
-            12 => String::from("Q"),
-            13 => String::from("K"),
-            _ => one_based_index.to_string(),
-        }
-    }
 }
 
-/// Return owned string representing the card. Examples:
-/// K♥ A♣ Q♥ 3♦ 7 8♠ 2♥
-impl fmt::Display for Card {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}{}", self.index_to_string(), self.suit_to_string())
-    }
-}
+//////////////////////////////////////////////////////////////////////////////////////
 
 #[cfg(test)]
 mod tests {
 
     use crate::card::Card;
+    use crate::card::Hand;
+    use crate::card::Rank;
+    use crate::card::Suit;
     use rand::SeedableRng;
 
     /// Ensure that
@@ -109,15 +161,28 @@ mod tests {
         let mut rng = rand::rngs::StdRng::seed_from_u64(15234202);
 
         for trial in 0..1000 {
-            let cards = Card::draw_seven_cards(&mut rng);
+            let hand = Hand::<7>::draw(&mut rng);
             for i in 1..7 {
                 for j in 0..i {
                     assert_ne!(
-                        cards[i].id, cards[j].id,
+                        hand.cards[i].id, hand.cards[j].id,
                         "trial: {trial}, i: {i}, j: {j}, left: {}, right: {}",
-                        cards[i], cards[j]
+                        hand.cards[i], hand.cards[j]
                     );
                 }
+            }
+        }
+    }
+
+    #[test]
+    fn card_constructor_from_rank_and_suit_test() {
+        for rank_id in 0..Rank::NUM_RANKS {
+            for suit_id in 0..Suit::NUM_SUITS {
+                let rank = Rank { id: rank_id };
+                let suit = Suit { id: suit_id };
+                let card = Card::new(&rank, &suit);
+                assert_eq!(card.suit(), suit);
+                assert_eq!(card.rank(), rank);
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod card;
 
 use crate::card::Card;
+use crate::card::Hand;
 
 /// Simple demo for the `poker-stats` crate. For now it
 /// does not support any arguments. It will do three things:
@@ -13,23 +14,25 @@ fn main() {
     println!("Sorted Deck:");
     for id in 0..52 {
         let card = Card { id };
-        if card.suit() == 3 {
+        if card.suit().id == 3 {
             println!("  {}", card);
         } else {
             print!("  {}  ", card);
         }
     }
-    println!("");
+    println!();
 
     print!("Five Cards: ");
-    for my_card in Card::draw_five_cards(&mut rng) {
-        print!("{} ", my_card);
+    let five_card_hand = Hand::<5>::draw(&mut rng);
+    for card in five_card_hand.cards {
+        print!("{} ", card);
     }
-    println!("");
+    println!();
 
     print!("Seven Cards: ");
-    for my_card in Card::draw_seven_cards(&mut rng) {
-        print!("{} ", my_card);
+    let seven_card_hand = Hand::<7>::draw(&mut rng);
+    for card in seven_card_hand.cards {
+        print!("{} ", card);
     }
-    println!("");
+    println!();
 }


### PR DESCRIPTION
Adds a collection of simple utility structs to make it a bit more clear what is going on in the code, and replace most hard-coded constants with named constants associated with a type.

Fix a minor bug in `draw_random_card`, where the upper bound of the range was actually 50 instead of 51, thus making it impossible to draw the king of spades.

Run `cargo clippy` on the project and fix all standard lints.